### PR TITLE
Added default impl for ModifiersState

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1614,6 +1614,19 @@ impl ModifiersState
     }
 }
 
+impl Default for ModifiersState
+{
+    fn default() -> Self
+    {
+        ModifiersState {
+            ctrl: false,
+            alt: false,
+            shift: false,
+            logo: false
+        }
+    }
+}
+
 impl From<glutin::event::ModifiersState> for ModifiersState
 {
     fn from(state: glutin::event::ModifiersState) -> Self


### PR DESCRIPTION
It is convenient to store current state of modifiers to process them in mouse click or something else.
But there is no way to create "empty" state, unless using `Option`. It is not very convenient to carry around an `Option`, so the `default()` method is more appropriate approach.