### PR TITLE
Implement transparent window creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ image = { version = "0.23", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # For windowing feature
-glutin = { version = "0.26", optional = true }
+glutin = { version = "0.28", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
@@ -69,7 +69,7 @@ simple_logger = { version = "1.11", default-features = false, features = ["color
 image = { version = "0.23" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-glutin = "0.26"
+glutin = "0.28"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1095,7 +1095,7 @@ impl WindowCreationOptions
             resizable: true,
             maximized: false,
             decorations: true,
-            transparent: false,
+            transparent: false
         }
     }
 
@@ -1165,7 +1165,7 @@ impl WindowCreationOptions
         self
     }
 
-    /// Sets whether the background of the window should be transparent. The 
+    /// Sets whether the background of the window should be transparent. The
     /// default is `false`.
     ///
     /// Note that this depends on platform support, and setting this may have no

--- a/src/window.rs
+++ b/src/window.rs
@@ -1061,6 +1061,7 @@ pub struct WindowCreationOptions
     pub(crate) always_on_top: bool,
     pub(crate) resizable: bool,
     pub(crate) maximized: bool,
+    pub(crate) transparent: bool,
     pub(crate) decorations: bool
 }
 
@@ -1093,7 +1094,8 @@ impl WindowCreationOptions
             always_on_top: false,
             resizable: true,
             maximized: false,
-            decorations: true
+            decorations: true,
+            transparent: false,
         }
     }
 
@@ -1160,6 +1162,19 @@ impl WindowCreationOptions
     pub fn with_decorations(mut self, decorations: bool) -> Self
     {
         self.decorations = decorations;
+        self
+    }
+
+    /// Sets whether the background of the window should be transparent. The 
+    /// default is `false`.
+    ///
+    /// Note that this depends on platform support, and setting this may have no
+    /// effect.
+    #[inline]
+    #[must_use]
+    pub fn with_transparent(mut self, transparent: bool) -> Self
+    {
+        self.transparent = transparent;
         self
     }
 }

--- a/src/window_internal_glutin.rs
+++ b/src/window_internal_glutin.rs
@@ -305,6 +305,7 @@ impl<UserEventType: 'static> WindowGlutin<UserEventType>
             .with_always_on_top(options.always_on_top)
             .with_maximized(options.maximized)
             .with_visible(false)
+            .with_transparent(options.transparent)
             .with_decorations(options.decorations);
 
         match &options.mode {


### PR DESCRIPTION
- Extended the `WindowCreationOptions` wrapper by adding a `transparent`
  option
- The `transparent` option maps directly to the `winit::WindowBuilder`
  option of the same name
- Updated the `glutin` dependency to from `0.26` to `0.28` in order to
  avoid a transparency related bug