### PR TITLE
Fix the window *jumping* while initial positioning

### DIFF
--- a/src/window_internal_glutin.rs
+++ b/src/window_internal_glutin.rs
@@ -304,6 +304,7 @@ impl<UserEventType: 'static> WindowGlutin<UserEventType>
             .with_resizable(options.resizable)
             .with_always_on_top(options.always_on_top)
             .with_maximized(options.maximized)
+            .with_visible(false)
             .with_decorations(options.decorations);
 
         match &options.mode {
@@ -347,6 +348,9 @@ impl<UserEventType: 'static> WindowGlutin<UserEventType>
                 // Nothing to do
             }
         }
+
+        // Show window after positioning to avoid the window jumping around
+        window_context.window().set_visible(true);
 
         let glow_context = unsafe {
             glow::Context::from_loader_function(|ptr| {

--- a/src/window_internal_glutin.rs
+++ b/src/window_internal_glutin.rs
@@ -337,20 +337,25 @@ impl<UserEventType: 'static> WindowGlutin<UserEventType>
             }
         });
 
-        match &options.mode {
-            WindowCreationMode::Windowed { position, .. } => {
-                if let Some(position) = position {
-                    position_window(&primary_monitor, window_context.window(), position);
-                }
-            }
-
-            WindowCreationMode::FullscreenBorderless => {
-                // Nothing to do
-            }
+        if let WindowCreationMode::Windowed {
+            position: Some(position),
+            ..
+        } = &options.mode
+        {
+            position_window(&primary_monitor, window_context.window(), position);
         }
 
         // Show window after positioning to avoid the window jumping around
         window_context.window().set_visible(true);
+
+        // Set the position again to work around an issue on Linux
+        if let WindowCreationMode::Windowed {
+            position: Some(position),
+            ..
+        } = &options.mode
+        {
+            position_window(&primary_monitor, window_context.window(), position);
+        }
 
         let glow_context = unsafe {
             glow::Context::from_loader_function(|ptr| {


### PR DESCRIPTION
- When the window is initially positioned, it is spawned on the default
  position and then moved to the actual correct position
- This can be seen visually as the window *jumping* around
- To fix this, the window is set to be hidding at creation time and is
  only shown after the positioning is completed