### PR TITLE
Added mouse passthrough window option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ image = { version = "0.23", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # For windowing feature
-glutin = { version = "0.28", optional = true }
+glutin = { version = "0.29.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
@@ -69,7 +69,7 @@ simple_logger = { version = "1.11", default-features = false, features = ["color
 image = { version = "0.23" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-glutin = "0.28"
+glutin = "0.29.1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1054,7 +1054,8 @@ pub struct WindowCreationOptions
     pub(crate) resizable: bool,
     pub(crate) maximized: bool,
     pub(crate) transparent: bool,
-    pub(crate) decorations: bool
+    pub(crate) decorations: bool,
+    pub(crate) mouse_passthrough: bool,
 }
 
 impl WindowCreationOptions
@@ -1087,7 +1088,8 @@ impl WindowCreationOptions
             resizable: true,
             maximized: false,
             decorations: true,
-            transparent: false
+            transparent: false,
+            mouse_passthrough: false
         }
     }
 
@@ -1167,6 +1169,19 @@ impl WindowCreationOptions
     pub fn with_transparent(mut self, transparent: bool) -> Self
     {
         self.transparent = transparent;
+        self
+    }
+
+    /// Sets whether mouse clicks should passthrough the window
+    /// default is `false`.
+    ///
+    /// Note that this depends on platform support, and setting this may have no
+    /// effect.
+    #[inline]
+    #[must_use]
+    pub fn with_mouse_passthrough(mut self, mouse_passthrough: bool) -> Self
+    {
+        self.mouse_passthrough = mouse_passthrough;
         self
     }
 }


### PR DESCRIPTION
Closes https://github.com/QuantumBadger/Speedy2D/issues/68

Turns out bumping the version of `glutin` to 0.29.1 makes this function available:
`self.window_context.window().set_cursor_hittest(!passthrough).unwrap();`
which makes mouse passthrough events possible.
`WindowCreationOptions` now has `.with_mouse_passthrough(bool)`

However with then newer version of Glutin, cursor grab is changed from a bool to an enum `CursorGrabMode`.
I did a somewhat ugly hack for this so I might need some advice on the best way to fix it up.