### PR TITLE
Added window size getter to WindowHelper

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -452,8 +452,8 @@ impl WebCanvasElement
     #[cfg(feature = "windowing")]
     pub fn get_canvas_size(&self) -> UVec2
     {
-        let width = self.canvas.width() as u32;
-        let height = self.canvas.height() as u32;
+        let width = self.canvas.width();
+        let height = self.canvas.height();
 
         UVec2::new(width, height)
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -449,6 +449,7 @@ impl WebCanvasElement
         &self.html_element
     }
 
+    #[cfg(feature = "windowing")]
     pub fn get_canvas_size(&self) -> UVec2
     {
         let width = self.canvas.width() as u32;

--- a/src/web.rs
+++ b/src/web.rs
@@ -449,6 +449,14 @@ impl WebCanvasElement
         &self.html_element
     }
 
+    pub fn get_canvas_size(&self) -> UVec2
+    {
+        let width = self.canvas.width() as u32;
+        let height = self.canvas.height() as u32;
+
+        UVec2::new(width, height)
+    }
+
     pub fn get_webgl2_context<V>(
         &self,
         viewport_size_pixels: V

--- a/src/window.rs
+++ b/src/window.rs
@@ -604,6 +604,12 @@ impl<UserEventType> WindowHelper<UserEventType>
         self.inner.set_size_pixels(size)
     }
 
+    /// Gets the window size in pixels.
+    pub fn get_size_pixels(&self) -> UVec2
+    {
+        self.inner.get_size_pixels()
+    }
+
     /// Sets the position of the window in pixels. If multiple monitors are in
     /// use, this will be the distance from the top left of the display
     /// area, spanning all the monitors.

--- a/src/window_internal_glutin.rs
+++ b/src/window_internal_glutin.rs
@@ -222,6 +222,13 @@ impl<UserEventType> WindowHelperGlutin<UserEventType>
             .set_inner_size(PhysicalSize::new(size.x, size.y));
     }
 
+    pub fn get_size_pixels(&self) -> UVec2
+    {
+        let size = self.window_context.window().inner_size();
+
+        UVec2::new(size.width, size.height)
+    }
+
     pub fn set_size_scaled_pixels<S: Into<Vec2>>(&self, size: S)
     {
         let size = size.into();

--- a/src/window_internal_web.rs
+++ b/src/window_internal_web.rs
@@ -522,6 +522,11 @@ impl<UserEventType: 'static> WindowHelperWeb<UserEventType>
     {
         // Do nothing
     }
+    pub fn get_size_pixels(&self) -> UVec2
+    {
+        let size = self.canvas.get_bounding_client_rect();
+    }
+
 
     pub fn set_position_pixels<P: Into<IVec2>>(&self, _position: P)
     {

--- a/src/window_internal_web.rs
+++ b/src/window_internal_web.rs
@@ -524,9 +524,8 @@ impl<UserEventType: 'static> WindowHelperWeb<UserEventType>
     }
     pub fn get_size_pixels(&self) -> UVec2
     {
-        let size = self.canvas.get_bounding_client_rect();
+        self.canvas.get_canvas_size()
     }
-
 
     pub fn set_position_pixels<P: Into<IVec2>>(&self, _position: P)
     {


### PR DESCRIPTION
The various structs have a lot of setters but lack many getters that would be very useful to use, like a get_pixel_size method to get the viewport size. 
This should address #76 

I also added a draw_rectangle_ref function because sometimes I want to keep my rectangle without moving it into draw_rectangle()