### PR TITLE
Make items serde serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ documentation = "https://docs.rs/speedy2d"
 default = ["windowing", "image-loading"]
 windowing = ["glutin", "winit", "glutin-winit", "raw-window-handle"]
 image-loading = ["image"]
+serde = ["dep:serde"]
 
 [dependencies]
 glow = "0.7"
@@ -32,6 +33,9 @@ smallvec = "1.9.0"
 
 # For image_loading feature
 image = { version = "0.23", optional = true }
+
+# For serde feature
+serde = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # For windowing feature

--- a/src/color.rs
+++ b/src/color.rs
@@ -16,6 +16,7 @@
 
 /// A struct representing a color with red, green, blue, and alpha components.
 /// Each component is stored as a float.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Color
 {

--- a/src/dimen.rs
+++ b/src/dimen.rs
@@ -33,6 +33,7 @@ pub type UVec2 = Vector2<u32>;
 /// A vector containing two numeric values. This may represent a size or
 /// position.
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
 pub struct Vector2<T>
 {

--- a/src/window.rs
+++ b/src/window.rs
@@ -720,6 +720,7 @@ impl WindowStartupInfo
 
 /// Identifies a mouse button.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum MouseButton
 {
@@ -739,6 +740,7 @@ pub enum MouseButton
 
 /// Describes a difference in the mouse scroll wheel position.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseScrollDistance
 {
     /// Number of lines or rows to scroll in each direction. The `y` field
@@ -787,6 +789,7 @@ pub enum MouseScrollDistance
 
 /// A virtual key code.
 #[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum VirtualKeyCode
@@ -1033,6 +1036,7 @@ pub(crate) enum WindowCreationMode
 
 /// The size of the window to create.
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowSize
 {
     /// Define the window size in pixels.
@@ -1049,6 +1053,7 @@ pub enum WindowSize
 
 /// The position of the window to create.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowPosition
 {
     /// Place the window in the center of the primary monitor.
@@ -1060,6 +1065,7 @@ pub enum WindowPosition
 
 /// Whether or not the window is in fullscreen mode.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowFullscreenMode
 {
     /// Non-fullscreen mode.


### PR DESCRIPTION
Added a "serde" feature. If this is enabled, certain enums and structs will be serde serializable. This allows them to (for example) be used with [RON](https://github.com/ron-rs/ron).