### PR TITLE
Added an ability to set/change mouse cursor pointers.

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -573,6 +573,12 @@ impl<UserEventType> WindowHelper<UserEventType>
         self.inner.set_cursor_grab(grabbed)
     }
 
+    /// Sets the shape of the mouse cursor shown over the window.
+    pub fn set_cursor(&self, cursor: MouseCursorType)
+    {
+        self.inner.set_cursor(cursor)
+    }
+
     /// Set to false to prevent the user from resizing the window.
     ///
     /// For `WebCanvas`, this function has no effect.
@@ -735,6 +741,66 @@ pub enum MouseButton
     Forward,
     /// Another mouse button, identified by a number.
     Other(u16)
+}
+
+/// Identifies the shape of the mouse cursor displayed over the window. See
+/// [WindowHelper::set_cursor].
+///
+/// The variants mirror the standard CSS cursor keywords and map directly onto
+/// the native cursors provided by each platform backend.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum MouseCursorType
+{
+    /// The platform-dependent default cursor (usually an arrow).
+    #[default]
+    Default,
+    /// A pointing hand, typically used to indicate a link.
+    Pointer,
+    /// A crosshair.
+    Crosshair,
+    /// Indicates editable text (usually an I-beam).
+    Text,
+    /// Indicates editable vertical text.
+    VerticalText,
+    /// Indicates that something can be moved.
+    Move,
+    /// Indicates that something can be grabbed (an open hand).
+    Grab,
+    /// Indicates that something is being grabbed (a closed hand).
+    Grabbing,
+    /// Indicates that the program is busy and the user should wait.
+    Wait,
+    /// Indicates that the program is busy in the background, but the user can
+    /// still interact with the interface.
+    Progress,
+    /// Indicates that a cell or set of cells may be selected.
+    Cell,
+    /// Indicates an alias of/shortcut to something is to be created.
+    Alias,
+    /// Indicates something is to be copied.
+    Copy,
+    /// Indicates that the dragged item cannot be dropped at the current
+    /// location.
+    NoDrop,
+    /// Indicates that the requested action will not be carried out.
+    NotAllowed,
+    /// Indicates that an edge of a box is to be moved left/right.
+    ColResize,
+    /// Indicates that an edge of a box is to be moved up/down.
+    RowResize,
+    /// Indicates a horizontal (east-west) resize.
+    EwResize,
+    /// Indicates a vertical (north-south) resize.
+    NsResize,
+    /// Indicates a bidirectional north-east/south-west resize.
+    NeswResize,
+    /// Indicates a bidirectional north-west/south-east resize.
+    NwseResize,
+    /// Indicates that something can be zoomed in.
+    ZoomIn,
+    /// Indicates that something can be zoomed out.
+    ZoomOut
 }
 
 /// Describes a difference in the mouse scroll wheel position.

--- a/src/window_internal_glutin.rs
+++ b/src/window_internal_glutin.rs
@@ -59,6 +59,7 @@ use winit::monitor::MonitorHandle;
 use winit::platform::scancode::PhysicalKeyExtScancode;
 use winit::window::{
     CursorGrabMode,
+    CursorIcon,
     Icon,
     Window as GlutinWindow,
     Window,
@@ -76,6 +77,7 @@ use crate::window::{
     EventLoopSendError,
     ModifiersState,
     MouseButton,
+    MouseCursorType,
     MouseScrollDistance,
     UserEventSender,
     VirtualKeyCode,
@@ -166,6 +168,11 @@ impl<UserEventType> WindowHelperGlutin<UserEventType>
     pub fn set_cursor_visible(&self, visible: bool)
     {
         self.window.set_cursor_visible(visible);
+    }
+
+    pub fn set_cursor(&self, cursor: MouseCursorType)
+    {
+        self.window.set_cursor_icon(cursor.into());
     }
 
     pub fn set_cursor_grab(
@@ -883,6 +890,38 @@ impl From<winit::event::MouseButton> for MouseButton
             winit::event::MouseButton::Other(id) => MouseButton::Other(id),
             winit::event::MouseButton::Back => MouseButton::Back,
             winit::event::MouseButton::Forward => MouseButton::Forward
+        }
+    }
+}
+
+impl From<MouseCursorType> for CursorIcon
+{
+    fn from(cursor: MouseCursorType) -> Self
+    {
+        match cursor {
+            MouseCursorType::Default => CursorIcon::Default,
+            MouseCursorType::Pointer => CursorIcon::Pointer,
+            MouseCursorType::Crosshair => CursorIcon::Crosshair,
+            MouseCursorType::Text => CursorIcon::Text,
+            MouseCursorType::VerticalText => CursorIcon::VerticalText,
+            MouseCursorType::Move => CursorIcon::Move,
+            MouseCursorType::Grab => CursorIcon::Grab,
+            MouseCursorType::Grabbing => CursorIcon::Grabbing,
+            MouseCursorType::Wait => CursorIcon::Wait,
+            MouseCursorType::Progress => CursorIcon::Progress,
+            MouseCursorType::Cell => CursorIcon::Cell,
+            MouseCursorType::Alias => CursorIcon::Alias,
+            MouseCursorType::Copy => CursorIcon::Copy,
+            MouseCursorType::NoDrop => CursorIcon::NoDrop,
+            MouseCursorType::NotAllowed => CursorIcon::NotAllowed,
+            MouseCursorType::ColResize => CursorIcon::ColResize,
+            MouseCursorType::RowResize => CursorIcon::RowResize,
+            MouseCursorType::EwResize => CursorIcon::EwResize,
+            MouseCursorType::NsResize => CursorIcon::NsResize,
+            MouseCursorType::NeswResize => CursorIcon::NeswResize,
+            MouseCursorType::NwseResize => CursorIcon::NwseResize,
+            MouseCursorType::ZoomIn => CursorIcon::ZoomIn,
+            MouseCursorType::ZoomOut => CursorIcon::ZoomOut
         }
     }
 }

--- a/src/window_internal_web.rs
+++ b/src/window_internal_web.rs
@@ -34,6 +34,7 @@ use crate::window::{
     KeyScancode,
     ModifiersState,
     MouseButton,
+    MouseCursorType,
     MouseScrollDistance,
     UserEventSender,
     VirtualKeyCode,
@@ -377,6 +378,38 @@ enum KeyEventType
     Up
 }
 
+impl From<MouseCursorType> for WebCursorType
+{
+    fn from(cursor: MouseCursorType) -> Self
+    {
+        match cursor {
+            MouseCursorType::Default => WebCursorType::Default,
+            MouseCursorType::Pointer => WebCursorType::Pointer,
+            MouseCursorType::Crosshair => WebCursorType::Crosshair,
+            MouseCursorType::Text => WebCursorType::Text,
+            MouseCursorType::VerticalText => WebCursorType::VerticalText,
+            MouseCursorType::Move => WebCursorType::Move,
+            MouseCursorType::Grab => WebCursorType::Grab,
+            MouseCursorType::Grabbing => WebCursorType::Grabbing,
+            MouseCursorType::Wait => WebCursorType::Wait,
+            MouseCursorType::Progress => WebCursorType::Progress,
+            MouseCursorType::Cell => WebCursorType::Cell,
+            MouseCursorType::Alias => WebCursorType::Alias,
+            MouseCursorType::Copy => WebCursorType::Copy,
+            MouseCursorType::NoDrop => WebCursorType::NoDrop,
+            MouseCursorType::NotAllowed => WebCursorType::NotAllowed,
+            MouseCursorType::ColResize => WebCursorType::ColResize,
+            MouseCursorType::RowResize => WebCursorType::RowResize,
+            MouseCursorType::EwResize => WebCursorType::EWResize,
+            MouseCursorType::NsResize => WebCursorType::NSResize,
+            MouseCursorType::NeswResize => WebCursorType::NESWResize,
+            MouseCursorType::NwseResize => WebCursorType::NWSEResize,
+            MouseCursorType::ZoomIn => WebCursorType::ZoomIn,
+            MouseCursorType::ZoomOut => WebCursorType::ZoomOut
+        }
+    }
+}
+
 pub struct WindowHelperWeb<UserEventType>
 where
     UserEventType: 'static
@@ -462,6 +495,11 @@ impl<UserEventType: 'static> WindowHelperWeb<UserEventType>
         } else {
             self.canvas.set_cursor(WebCursorType::None);
         }
+    }
+
+    pub fn set_cursor(&self, cursor: MouseCursorType)
+    {
+        self.canvas.set_cursor(cursor.into());
     }
 
     pub fn set_cursor_grab(


### PR DESCRIPTION
Added cursor-icon changing support to WindowHelper
  
This adds the ability to change the mouse cursor shape, which was previously missing on the desktop backend (only set_cursor_visible / set_cursor_grab were exposed), fixes #30.

  - New MouseCursorType enum (CSS-style cursor set: Pointer, Text, Grab, resize cursors, etc.).
  - New WindowHelper::set_cursor(MouseCursorType).
  - Mapped to winit::window::CursorIcon on the glutin backend and the existing WebCursorType on web.